### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/bcsoft-career-graph/00a1bd3b-773b-4c1f-a765-de3d0aad6126/d1df14c9-189e-4d23-8cd0-fb7083a611fa/_apis/work/boardbadge/360542a5-95bc-4d2c-848f-d5de861ae6ec)](https://dev.azure.com/bcsoft-career-graph/00a1bd3b-773b-4c1f-a765-de3d0aad6126/_boards/board/t/d1df14c9-189e-4d23-8cd0-fb7083a611fa/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/bcsoft-career-graph/00a1bd3b-773b-4c1f-a765-de3d0aad6126/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.